### PR TITLE
Updated ci/cd to stop running image comparisons

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -14,6 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      CI: true
     steps:
       - uses: actions/checkout@v3
 

--- a/tests/testthat/test_001_plotter.R
+++ b/tests/testthat/test_001_plotter.R
@@ -1,202 +1,270 @@
-testthat::test_that("Plot two groups correctly", {
+describe("Testing dabest_plot function", {
+  skip_on_cran() # skips all tests below if env var NOT_CRAN=false
+  skip_on_ci() # skips all tests below if env var CI=true
+  
   np_dataset <- generate_non_proportional_dataset()
-
-  #### 2GROUP ####
-  unpaired_mean_diff <- dabestr::load(np_dataset, x = Group, y = Measurement, idx = c("Control 1", "Test 1")) %>%
-    dabestr::mean_diff()
-
-  #### FLOAT TRUE ####
-  unpaired_mean_diff_float_true <- dabestr::dabest_plot(unpaired_mean_diff, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("two-groups unpaired mean diff float true", unpaired_mean_diff_float_true)
-
-  #### FLOAT FALSE ####
-  unpaired_mean_diff_float_false <- dabestr::dabest_plot(unpaired_mean_diff, float_contrast = FALSE)
-  vdiffr::expect_doppelganger("two-groups unpaired mean diff float false", unpaired_mean_diff_float_false)
-})
-
-testthat::test_that("Plot two groups colour correctly", {
-  np_dataset <- generate_non_proportional_dataset()
-
-  #### 2GROUP COLOUR ####
-  unpaired_mean_diff_colour <- dabestr::load(np_dataset,
-    x = Group, y = Measurement,
-    idx = c("Control 1", "Test 1"),
-    colour = Gender
-  ) %>%
-    dabestr::mean_diff()
-
-  #### FLOAT TRUE ####
-  unpaired_mean_diff_colour_float_true <- dabestr::dabest_plot(unpaired_mean_diff_colour, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("two-groups unpaired mean diff colour float true", unpaired_mean_diff_colour_float_true)
-
-  #### FLOAT FALSE ####
-  unpaired_mean_diff_colour_float_false <- dabestr::dabest_plot(unpaired_mean_diff_colour, float_contrast = FALSE)
-  vdiffr::expect_doppelganger("two-groups unpaired mean diff colour float false", unpaired_mean_diff_colour_float_false)
-})
-
-testthat::test_that("Plot multi groups correctly", {
-  np_dataset <- generate_non_proportional_dataset()
-
-  #### MULTIGROUP UNPAIRED ####
-  multi_unpaired <- dabestr::load(np_dataset,
-    x = Group, y = Measurement,
-    idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3"))
-  ) %>%
-    dabestr::mean_diff()
-
-  multi_unpaired <- dabestr::dabest_plot(multi_unpaired, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("multigroup unpaired mean diff", multi_unpaired)
-
-  #### MULTIGROUP COLOUR UNPAIRED ####
-  multi_unpaired_colour <- dabestr::load(np_dataset,
-    x = Group, y = Measurement,
-    idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3")),
-    colour = Gender
-  ) %>%
-    dabestr::mean_diff()
-
-  multi_unpaired_colour <- dabestr::dabest_plot(multi_unpaired_colour, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("multigroup unpaired mean diff colour", multi_unpaired_colour)
-
-  #### MULTIGROUP SEQUENTIAL ####
-  multi_sequential <- dabestr::load(np_dataset,
-    x = Group, y = Measurement,
-    idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3")),
-    paired = "sequential", id_col = ID
-  ) %>%
-    dabestr::mean_diff()
-
-  multi_sequential <- dabestr::dabest_plot(multi_sequential, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("multigroup sequential mean diff", multi_sequential)
-
-  #### MULTIGROUP BASELINE ####
-  multi_baseline <- dabestr::load(np_dataset,
-    x = Group, y = Measurement,
-    idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3")),
-    paired = "baseline", id_col = ID
-  ) %>%
-    dabestr::mean_diff()
-
-  multi_baseline <- dabestr::dabest_plot(multi_baseline, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("multigroup baseline mean diff", multi_baseline)
-
-  #### MULTIGROUP BASELINE COLOUR ####
-  multi_baseline_colour <- dabestr::load(np_dataset,
-    x = Group, y = Measurement,
-    idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3")),
-    paired = "baseline", id_col = ID, colour = Gender
-  ) %>%
-    dabestr::mean_diff()
-
-  multi_baseline_colour <- dabestr::dabest_plot(multi_baseline_colour, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("multigroup baseline colour mean diff", multi_baseline_colour)
-})
-
-testthat::test_that("Plot unpaired proportions correctly", {
   p_dataset <- generate_proportional_dataset()
-
-  #### 2GROUP PROPORTION UNPAIRED ####
-  unpaired_mean_diff <- dabestr::load(p_dataset,
-    x = Group, y = Success,
-    idx = c("Control 1", "Test 1"),
-    proportional = TRUE
-  ) %>%
-    dabestr::mean_diff()
-
-  #### FLOAT TRUE ####
-  unpaired_mean_diff_float_true <- dabestr::dabest_plot(unpaired_mean_diff, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("proportion unpaired mean diff float true", unpaired_mean_diff_float_true)
-
-  #### FLOAT FALSE ####
-  unpaired_mean_diff_float_false <- dabestr::dabest_plot(unpaired_mean_diff, float_contrast = FALSE)
-  vdiffr::expect_doppelganger("proportion unpaired mean diff float false", unpaired_mean_diff_float_false)
-
-  #### MULTIGROUP PROPORTION UNPAIRED ####
-  multi_unpaired <- dabestr::load(p_dataset,
-    x = Group, y = Success,
-    idx = c("Control 1", "Test 1", "Test 2"),
-    proportional = TRUE
-  ) %>%
-    dabestr::mean_diff()
-
-  multi_unpaired <- dabestr::dabest_plot(multi_unpaired, float_contrast = FALSE)
-  vdiffr::expect_doppelganger("proportion unpaired multigroup mean diff", multi_unpaired)
-})
-
-testthat::test_that("Plot paired proportions correctly", {
-  p_dataset <- generate_proportional_dataset()
-
-  #### 2GROUP PROPORTION BASELINE ####
-  paired_mean_diff <- dabestr::load(p_dataset,
-    x = Group, y = Success,
-    idx = c("Control 1", "Test 1"),
-    proportional = TRUE, paired = "baseline",
-    id_col = ID
-  ) %>%
-    dabestr::mean_diff()
-
-  #### FLOAT TRUE ####
-  paired_mean_diff_float_true <- dabestr::dabest_plot(paired_mean_diff, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("proportion paired mean diff float true", paired_mean_diff_float_true)
-
-  #### FLOAT FALSE ####
-  paired_mean_diff_float_false <- dabestr::dabest_plot(paired_mean_diff, float_contrast = FALSE)
-  vdiffr::expect_doppelganger("proportion paired mean diff float false", paired_mean_diff_float_false)
-
-  #### MULTIGROUP PROPORTION SEQUENTIAL ####
-  multi_sequential <- dabestr::load(p_dataset,
-    x = Group, y = Success,
-    idx = list(c("Control 1", "Test 1", "Test 2", "Test 3"), c("Control 2", "Test 4")),
-    proportional = TRUE, paired = "sequential",
-    id_col = ID
-  ) %>%
-    dabestr::mean_diff()
-
-  multi_sequential <- dabestr::dabest_plot(multi_sequential, float_contrast = FALSE)
-  vdiffr::expect_doppelganger("proportion sequential mean diff", multi_sequential)
-
-  #### MULTIGROUP PROPORTION BASELINE ####
-  multi_baseline <- dabestr::load(p_dataset,
-    x = Group, y = Success,
-    idx = list(c("Control 1", "Test 1", "Test 2", "Test 3"), c("Control 2", "Test 4")),
-    proportional = TRUE, paired = "baseline",
-    id_col = ID
-  ) %>%
-    dabestr::mean_diff()
-
-  multi_baseline_flow_true <- dabestr::dabest_plot(multi_baseline, float_contrast = FALSE)
-  vdiffr::expect_doppelganger("proportion baseline mean diff", multi_baseline_flow_true)
-
-  #### FLOW FALSE ####
-  multi_baseline_flow_false <- dabestr::dabest_plot(multi_baseline, float_contrast = FALSE, flow = FALSE)
-  vdiffr::expect_doppelganger("proportion baseline flow false mean diff", multi_baseline_flow_false)
-})
-
-testthat::test_that("Plot minimeta correctly", {
-  np_dataset <- generate_non_proportional_dataset()
-
-  #### MINIMETA ####
-  minimeta <- dabestr::load(np_dataset,
-    x = Group, y = Measurement,
-    idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2"), c("Control 3", "Test 3")),
-    minimeta = TRUE
-  ) %>%
-    dabestr::mean_diff()
-
-  minimeta <- dabestr::dabest_plot(minimeta, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("minimeta mean diff", minimeta)
-})
-
-testthat::test_that("Plot deltadelta correctly", {
   d_dataset <- generate_deltadelta_dataset()
-
-  #### DELTADELTA ####
-  deltadelta <- dabestr::load(d_dataset,
-    x = Genotype, y = Measurement, delta2 = TRUE, experiment = Treatment,
-    idx = list(c("W Placebo", "M Placebo"), c("W Drug", "M Drug")), colour = Genotype
-  ) %>%
-    dabestr::mean_diff()
-
-  deltadelta <- dabestr::dabest_plot(deltadelta, float_contrast = TRUE)
-  vdiffr::expect_doppelganger("deltadelta mean diff", deltadelta)
+  
+  describe("Given it is a two group plot", {
+    #### 2GROUP ####
+    unpaired_mean_diff <- dabestr::load(np_dataset, x = Group, y = Measurement, idx = c("Control 1", "Test 1")) %>%
+      dabestr::mean_diff()
+    
+    #### FLOAT TRUE ####
+    describe("Given that float_contrast is TRUE", {
+      test_that("it should generate the correct plot", {
+        unpaired_mean_diff_float_true <- dabestr::dabest_plot(unpaired_mean_diff, float_contrast = TRUE)
+        vdiffr::expect_doppelganger("two-groups unpaired mean diff float true", unpaired_mean_diff_float_true)
+      })
+    })
+    
+    #### FLOAT FALSE ####
+    describe("Given that float_contrast is FALSE", {
+      test_that("it should generate the correct plot", {
+        unpaired_mean_diff_float_false <- dabestr::dabest_plot(unpaired_mean_diff, float_contrast = FALSE)
+        vdiffr::expect_doppelganger("two-groups unpaired mean diff float false", unpaired_mean_diff_float_false)
+      })
+    })
+    
+    describe("Given that there is a colour column", {
+      #### 2GROUP COLOUR ####
+      unpaired_mean_diff_colour <- dabestr::load(np_dataset,
+                                                 x = Group, y = Measurement,
+                                                 idx = c("Control 1", "Test 1"),
+                                                 colour = Gender
+      ) %>% dabestr::mean_diff()
+      
+      describe("Given that float_contrast is TRUE", {
+        test_that("it should generate the correct plot", {
+          unpaired_mean_diff_colour_float_true <- dabestr::dabest_plot(unpaired_mean_diff_colour, float_contrast = TRUE)
+          vdiffr::expect_doppelganger("two-groups unpaired mean diff colour float true", unpaired_mean_diff_colour_float_true)
+        })
+      })
+      
+      describe("Given that float_contrast is FALSE", {
+        test_that("it should generate the correct plot", {
+          unpaired_mean_diff_colour_float_false <- dabestr::dabest_plot(unpaired_mean_diff_colour, float_contrast = FALSE)
+          vdiffr::expect_doppelganger("two-groups unpaired mean diff colour float false", unpaired_mean_diff_colour_float_false)
+        })
+      })
+    })
+  })
+  
+  describe("Given it is a multi-group plot", {
+    #### MULTIGROUP UNPAIRED ####
+    describe("Given that it is unpaired", {
+      multi_unpaired <- dabestr::load(np_dataset,
+                                      x = Group, y = Measurement,
+                                      idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3"))
+      ) %>% dabestr::mean_diff()
+      
+      test_that("it should generate the correct plot", {
+        multi_unpaired_plot <- dabestr::dabest_plot(multi_unpaired, float_contrast = TRUE)
+        vdiffr::expect_doppelganger("multigroup unpaired mean diff", multi_unpaired_plot)
+      })
+      
+      #### MULTIGROUP COLOUR UNPAIRED ####
+      describe("Given that it has a colour column", {
+        multi_unpaired_colour <- dabestr::load(np_dataset,
+                                               x = Group, y = Measurement,
+                                               idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3")),
+                                               colour = Gender
+        ) %>% dabestr::mean_diff()
+        
+        test_that("it should generate the correct plot with colour", {
+          multi_unpaired_colour_plot <- dabestr::dabest_plot(multi_unpaired_colour, float_contrast = TRUE)
+          vdiffr::expect_doppelganger("multigroup unpaired mean diff colour", multi_unpaired_colour_plot)
+        })
+      })
+    })
+    
+    #### MULTIGROUP SEQUENTIAL ####
+    describe("Given that the data is paired sequentially", {
+      multi_sequential <- dabestr::load(np_dataset,
+                                        x = Group, y = Measurement,
+                                        idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3")),
+                                        paired = "sequential", id_col = ID
+      ) %>% dabestr::mean_diff()
+      
+      test_that("it should generate the correct plot", {
+        multi_sequential_plot <- dabestr::dabest_plot(multi_sequential, float_contrast = TRUE)
+        vdiffr::expect_doppelganger("multigroup sequential mean diff", multi_sequential_plot)
+      })
+    })
+    
+    #### MULTIGROUP BASELINE ####
+    describe("Given that the data is paired with baseline", {
+      multi_baseline <- dabestr::load(np_dataset,
+                                      x = Group, y = Measurement,
+                                      idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3")),
+                                      paired = "baseline", id_col = ID
+      ) %>% dabestr::mean_diff()
+      
+      test_that("it should generate the correct baseline plot", {
+        multi_baseline_plot <- dabestr::dabest_plot(multi_baseline, float_contrast = TRUE)
+        vdiffr::expect_doppelganger("multigroup baseline mean diff", multi_baseline_plot)
+      })
+      
+      #### MULTIGROUP BASELINE COLOUR ####
+      describe("Given that there is a colour column", {
+        multi_baseline_colour <- dabestr::load(np_dataset,
+                                               x = Group, y = Measurement,
+                                               idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2", "Test 3")),
+                                               paired = "baseline", id_col = ID, colour = Gender
+        ) %>% dabestr::mean_diff()
+        test_that("it should generate the correct baseline plot with colour", {
+          multi_baseline_colour_plot <- dabestr::dabest_plot(multi_baseline_colour, float_contrast = TRUE)
+          vdiffr::expect_doppelganger("multigroup baseline colour mean diff", multi_baseline_colour_plot)
+        })
+      })
+    })
+  })
+  
+  describe("Given a proportional dataset", {
+    describe("Given that it is an unpaired proportions plot", {
+      #### 2GROUP PROPORTION UNPAIRED ####
+      describe("Given that it is two groups", {
+        unpaired_mean_diff <- dabestr::load(p_dataset,
+                                            x = Group, y = Success,
+                                            idx = c("Control 1", "Test 1"),
+                                            proportional = TRUE
+        ) %>%
+          dabestr::mean_diff()
+        
+        #### FLOAT TRUE ####
+        describe("Given that float_contrast is TRUE", {
+          test_that("it should generate the correct plot", {
+            unpaired_mean_diff_float_true <- dabestr::dabest_plot(unpaired_mean_diff, float_contrast = TRUE)
+            vdiffr::expect_doppelganger("proportion unpaired mean diff float true", unpaired_mean_diff_float_true)
+          })
+        })
+        
+        #### FLOAT FALSE ####
+        describe("Given that float_contrast is FALSE", {
+          test_that("it should generate the correct plot", {
+            unpaired_mean_diff_float_false <- dabestr::dabest_plot(unpaired_mean_diff, float_contrast = FALSE)
+            vdiffr::expect_doppelganger("proportion unpaired mean diff float false", unpaired_mean_diff_float_false)
+          })
+        })
+      })
+      
+      #### MULTIGROUP PROPORTION UNPAIRED ####
+      describe("Given that there are multi-groups", {
+        multi_unpaired <- dabestr::load(p_dataset,
+                                        x = Group, y = Success,
+                                        idx = c("Control 1", "Test 1", "Test 2"),
+                                        proportional = TRUE
+        ) %>%
+          dabestr::mean_diff()
+        
+        test_that("it should generate the correct plot", {
+          multi_unpaired <- dabestr::dabest_plot(multi_unpaired, float_contrast = FALSE)
+          vdiffr::expect_doppelganger("proportion unpaired multigroup mean diff", multi_unpaired)
+        })
+      })
+    })
+    
+    describe("Given that it is an paired proportions plot", {
+      #### 2GROUP PROPORTION BASELINE ####
+      describe("Given that it is 2 group and the data is paired baseline", {
+        paired_mean_diff <- dabestr::load(p_dataset,
+                                          x = Group, y = Success,
+                                          idx = c("Control 1", "Test 1"),
+                                          proportional = TRUE, paired = "baseline",
+                                          id_col = ID
+        ) %>%
+          dabestr::mean_diff()
+        
+        #### FLOAT TRUE ####
+        describe("Given that float_contrast is TRUE", {
+          test_that("it should generate the correct plot", {
+            paired_mean_diff_float_true <- dabestr::dabest_plot(paired_mean_diff, float_contrast = TRUE)
+            vdiffr::expect_doppelganger("proportion paired mean diff float true", paired_mean_diff_float_true)
+          })
+        })
+        
+        #### FLOAT FALSE ####
+        describe("Given that float_contrast is FALSE", {
+          test_that("it should generate the correct plot", {
+            paired_mean_diff_float_false <- dabestr::dabest_plot(paired_mean_diff, float_contrast = FALSE)
+            vdiffr::expect_doppelganger("proportion paired mean diff float false", paired_mean_diff_float_false)
+          })
+        })
+      })
+      
+      describe("Given that it is multigroup", {
+        #### MULTIGROUP PROPORTION SEQUENTIAL ####
+        describe("Given that the data is paired sequentially", {
+          multi_sequential <- dabestr::load(p_dataset,
+                                            x = Group, y = Success,
+                                            idx = list(c("Control 1", "Test 1", "Test 2", "Test 3"), c("Control 2", "Test 4")),
+                                            proportional = TRUE, paired = "sequential",
+                                            id_col = ID
+          ) %>%
+            dabestr::mean_diff()
+          
+          test_that("it should generate the correct plot", {
+            multi_sequential <- dabestr::dabest_plot(multi_sequential, float_contrast = FALSE)
+            vdiffr::expect_doppelganger("proportion sequential mean diff", multi_sequential)
+          })
+        })
+        
+        #### MULTIGROUP PROPORTION BASELINE ####
+        describe("Given that the data is paired with baseline", {
+          multi_baseline <- dabestr::load(p_dataset,
+                                          x = Group, y = Success,
+                                          idx = list(c("Control 1", "Test 1", "Test 2", "Test 3"), c("Control 2", "Test 4")),
+                                          proportional = TRUE, paired = "baseline",
+                                          id_col = ID
+          ) %>%
+            dabestr::mean_diff()
+          
+          test_that("it should generate the correct plot", {
+            multi_baseline_flow_true <- dabestr::dabest_plot(multi_baseline, float_contrast = FALSE)
+            vdiffr::expect_doppelganger("proportion baseline mean diff", multi_baseline_flow_true)
+          })
+          
+          #### FLOW FALSE ####
+          describe("Given that flow=FALSE", {
+            test_that("it should generate the correct plot", {
+              multi_baseline_flow_false <- dabestr::dabest_plot(multi_baseline, float_contrast = FALSE, flow = FALSE)
+              vdiffr::expect_doppelganger("proportion baseline flow false mean diff", multi_baseline_flow_false)
+            })
+          })
+        })
+      })
+    })
+  })
+  
+  describe("Given it is a minimeta plot", {
+    #### MINIMETA ####
+    minimeta <- dabestr::load(np_dataset,
+                              x = Group, y = Measurement,
+                              idx = list(c("Control 1", "Test 1"), c("Control 2", "Test 2"), c("Control 3", "Test 3")),
+                              minimeta = TRUE
+    ) %>%
+      dabestr::mean_diff()
+    
+    test_that("it should generate the correct plot", {
+      minimeta <- dabestr::dabest_plot(minimeta, float_contrast = TRUE)
+      vdiffr::expect_doppelganger("minimeta mean diff", minimeta)
+    })
+  })
+  
+  describe("Given a deltadelta dataset", {
+    describe("Given it is a deltadelta plot", {
+      #### DELTADELTA ####
+      deltadelta <- dabestr::load(d_dataset,
+                                  x = Genotype, y = Measurement, delta2 = TRUE, experiment = Treatment,
+                                  idx = list(c("W Placebo", "M Placebo"), c("W Drug", "M Drug")), colour = Genotype
+      ) %>%
+        dabestr::mean_diff()
+      
+      test_that("it should generate the correct plot", {
+        deltadelta <- dabestr::dabest_plot(deltadelta, float_contrast = TRUE)
+        vdiffr::expect_doppelganger("deltadelta mean diff", deltadelta)
+      })
+    })
+  })
 })


### PR DESCRIPTION
Changes:
- added `CI=true` value on yaml file to stop automatic running of image comparison tests in `test_001_plotter.R`
- refactored formatting of unit tests in `test_001_plotter.R`

Note:
- on dev side, moving forward, if we ever want to add new tests for various conditions, we can set env variables via `.Rnenviron` files in root directory file of the project. To load these environment variables, we can run `readRenviron(".Renviron")` in console before running the tests.

- CI/CD not fully fix yet:
<img width="1026" alt="Screenshot 2024-10-27 at 16 30 37" src="https://github.com/user-attachments/assets/97afb248-0e46-4821-8535-d4505d922fcc">

However, image comparison tests are being skipped successfully and tests are all passing 

<img width="719" alt="Screenshot 2024-10-27 at 16 34 26" src="https://github.com/user-attachments/assets/262c1a71-efce-4d4e-8521-56a79ccb031e">

For now, since R-CMD-CHECK is "failing" on CI/CD due to "warnings", not pressing to be fixed yet. Will try to fix in next CI/CD related PR. 