### PR TITLE
Allow users to input their own colour schemes, fixes for problems with >9 groups.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,4 +74,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.3

--- a/R/001_api.R
+++ b/R/001_api.R
@@ -301,6 +301,7 @@ load <- function(
 #' @noRd
 #'
 #' @param x a dabest object, set as x to tally with method signature for print functions
+#' @param print_greet_end a boolean value for printing with greeting/ending.
 #' @param ... S3 signature for generic plot function.
 #'
 #' @return A summary of the experimental designs.
@@ -319,29 +320,35 @@ load <- function(
 #' print(dabest_obj)
 #'
 #' @export
-print.dabest <- function(x, ...) {
+print.dabest <- function(x, print_greet_end = TRUE, ...) {
+
   dabest_obj <- x
 
   check_dabest_object(dabest_obj)
-
-  print_greeting_header()
+  cat("\n")
+  if (print_greet_end) {
+    print_greeting_header()
+  }
+  else cat("\n")
 
   paired <- dabest_obj$paired
   ci <- dabest_obj$ci
 
   # Use a lookup table for rm_status and paired_status
-  rm_status_lookup <- c(NULL = "", "sequential" = "for the sequential design of repeated-measures experiment \\n", "baseline" = "for repeated measures against baseline \\n")
-  paired_status_lookup <- c(NULL = "E", "sequential" = "Paired e", "baseline" = "Paired e")
+  rm_status_lookup <- c(NULL = "", "sequential" = "for the sequential design of repeated-measures experiment \n", "baseline" = "for repeated measures against baseline \n")
+  paired_status_lookup <- c(NULL = "Unpaired ", "sequential" = "Paired ", "baseline" = "Paired ")
 
-  rm_status <- rm_status_lookup[paired]
-  paired_status <- paired_status_lookup[paired]
+  rm_status <- rm_status_lookup[[format(paired)]]
+  paired_status <- paired_status_lookup[[format(paired)]]
 
   # Create strings
-  line1 <- paste0(paired_status, "ffect size(s) ", rm_status)
+  line1 <- paste0(paired_status, "effect size(s) ", rm_status)
   line2 <- paste0("with ", ci, "% confidence intervals will be computed for:")
   cat(line1)
   cat(line2)
   cat("\n")
   print_each_comparism(dabest_obj)
-  print_ending(dabest_obj)
+  if (print_greet_end) {
+    print_ending(dabest_obj)
+  }
 }

--- a/R/001_effsize_func.R
+++ b/R/001_effsize_func.R
@@ -307,6 +307,7 @@ cohens_h <- function(dabest_obj, perm_count = 5000) {
 #' @noRd
 #'
 #' @param x a dabest_effectsize_obj object, set as x to tally with method signature for print functions
+#' @param print_greet_end a boolean value for printing greeting/ending.
 #' @param ... S3 signature for generic plot function.
 #'
 #' @return A summary of the effect sizes and respective confidence intervals.
@@ -327,14 +328,18 @@ cohens_h <- function(dabest_obj, perm_count = 5000) {
 #' print(dabest_obj.mean_diff)
 #'
 #' @export
-print.dabest_effectsize <- function(x, ...) {
+print.dabest_effectsize <- function(x, print_greet_end = TRUE, ...) {
   dabest_effectsize_obj <- x
 
   check_effectsize_object(dabest_effectsize_obj)
-
-  print_greeting_header()
+  if (print_greet_end) {
+    print_greeting_header()
+  }
+  else cat("\n")
 
   es <- dabest_effectsize_obj$effect_size_type
   print_each_comparism_effectsize(dabest_effectsize_obj, es)
-  print_ending(dabest_effectsize_obj)
+  if (print_greet_end) {
+    print_ending(dabest_effectsize_obj)
+  }
 }

--- a/R/001_plotter.R
+++ b/R/001_plotter.R
@@ -50,8 +50,9 @@ dabest_plot <- function(dabest_effectsize_obj, float_contrast = TRUE, ...) {
   show_legend <- plot_kwargs$show_legend
   idx <- dabest_effectsize_obj$idx
   raw_legend <- NULL
+  total_groups <- length(unlist(idx))
 
-  if (length(unlist(idx)) >= 3) {
+  if (total_groups >= 3) {
     float_contrast <- FALSE
   }
 
@@ -60,8 +61,8 @@ dabest_plot <- function(dabest_effectsize_obj, float_contrast = TRUE, ...) {
 
   delta_plot <- delta_plot$delta_plot
 
-  raw_plot <- apply_palette(raw_plot, custom_palette, palette_values, length(unlist(idx)))
-  delta_plot <- apply_palette(delta_plot, custom_palette, palette_values, length(unlist(idx)))
+  raw_plot <- apply_palette(raw_plot, custom_palette, palette_values, total_groups, delta = FALSE)
+  delta_plot <- apply_palette(delta_plot, custom_palette, palette_values, total_groups, delta = TRUE)
 
   if (float_contrast) {
     final_plot <- cowplot::plot_grid(

--- a/R/001_plotter.R
+++ b/R/001_plotter.R
@@ -42,6 +42,7 @@ dabest_plot <- function(dabest_effectsize_obj, float_contrast = TRUE, ...) {
 
   plot_kwargs <- assign_plot_kwargs(dabest_effectsize_obj, plot_kwargs)
   custom_palette <- plot_kwargs$custom_palette
+  palette_values <- plot_kwargs$palette_values
 
   is_colour <- dabest_effectsize_obj$is_colour
   is_deltadelta <- plot_kwargs$show_delta2
@@ -59,8 +60,8 @@ dabest_plot <- function(dabest_effectsize_obj, float_contrast = TRUE, ...) {
 
   delta_plot <- delta_plot$delta_plot
 
-  raw_plot <- apply_palette(raw_plot, custom_palette)
-  delta_plot <- apply_palette(delta_plot, custom_palette)
+  raw_plot <- apply_palette(raw_plot, custom_palette, palette_values, length(unlist(idx)))
+  delta_plot <- apply_palette(delta_plot, custom_palette, palette_values, length(unlist(idx)))
 
   if (float_contrast) {
     final_plot <- cowplot::plot_grid(

--- a/R/002_plot_utils.R
+++ b/R/002_plot_utils.R
@@ -621,7 +621,7 @@ add_delta_text_to_delta_plot <- function(delta_plot,
     custom_colour <- "black"
   } else {
     # use the default palette colours of the ggplot violin plot object
-    colours <- get_palette_colours(plot_kwargs$custom_palette, max(x_values))
+    colours <- get_palette_colours(plot_kwargs$custom_palette, max(x_values), plot_kwargs$palette_values)
     # Select colors at positions specified by x_values
     delta_text_colours <- colours[x_values]
   }

--- a/R/002_plot_utils.R
+++ b/R/002_plot_utils.R
@@ -423,7 +423,7 @@ add_swarm_bars_to_raw_plot <- function(dabest_effectsize_obj, plot_kwargs, x_val
     swarm_bars_colours <- rep("black", length(x_values))
     custom_colour <- "black"
   } else {
-    swarm_bars_colours <- as.character(x_values)
+    swarm_bars_colours <- as.factor(x_values)
   }
 
   # Define width and height for each rectangle
@@ -497,7 +497,7 @@ add_contrast_bars_to_delta_plot <- function(dabest_effectsize_obj, plot_kwargs, 
     custom_colour <- "black"
   } else {
     # use the default palette colours of the ggplot violin plot object
-    contrast_bars_colours <- as.character((x_values))
+    contrast_bars_colours <- as.character(x_values)
     # contrast_bars_colours <- factor(as.character(x_values), levels = group_levels)
   }
 

--- a/R/005_printing.R
+++ b/R/005_printing.R
@@ -107,11 +107,11 @@ print_each_comparism_effectsize <- function(dabest_effectsize_obj, effectsize) {
   pvalue <- dabest_effectsize_obj$permtest_pvals$pval_for_tests
 
   # Use a lookup table for rm_status and paired_status
-  rm_status_lookup <- c(NULL = "", "sequential" = "for the sequential design of repeated-measures experiment \\n", "baseline" = "for repeated measures against baseline \\n")
+  rm_status_lookup <- c(NULL = "", "sequential" = "for the sequential design of repeated-measures experiment \n", "baseline" = "for repeated measures against baseline \n")
   paired_status_lookup <- c(NULL = "unpaired", "sequential" = "paired", "baseline" = "paired")
 
-  rm_status <- rm_status_lookup[paired]
-  paired_status <- paired_status_lookup[paired]
+  rm_status <- rm_status_lookup[[format(paired)]] # make sure even NULL gets converted to string
+  paired_status <- paired_status_lookup[[format(paired)]] # make sure even NULL gets converted to string
 
   if (is.list(dabest_effectsize_obj$idx)) {
     for (group in dabest_effectsize_obj$idx) {
@@ -133,7 +133,7 @@ print_each_comparism_effectsize <- function(dabest_effectsize_obj, effectsize) {
           current_ci <- ci[i]
           current_pval <- pvalue[i]
 
-          cat(stringr::str_interp("The ${paired_status} ${es} between ${current_test_group} and ${control_group} is ${current_difference} [${current_ci}%CI ${current_bca_low}, ${current_bca_high}].\n"))
+          cat(stringr::str_interp("The ${paired_status} ${es} between ${current_test_group} and ${control_group} is ${current_difference}, ${current_ci}% CI [${current_bca_low}, ${current_bca_high}].\n"))
           cat(stringr::str_interp("The p-value of the two-sided permutation t-test is ${sprintf(current_pval, fmt = '%#.4f')}, calculated for legacy purposes only."))
           cat("\n\n")
           i <- i + 1
@@ -149,7 +149,7 @@ print_each_comparism_effectsize <- function(dabest_effectsize_obj, effectsize) {
           current_ci <- ci[i]
           current_pval <- pvalue[i]
 
-          cat(stringr::str_interp("The ${paired_status} ${es} between ${current_group} and ${previous_group} is ${current_difference} [${current_ci}%CI ${current_bca_low}, ${current_bca_high}].\n"))
+          cat(stringr::str_interp("The ${paired_status} ${es} between ${current_group} and ${previous_group} is ${current_difference}, ${current_ci}% CI [${current_bca_low}, ${current_bca_high}].\n"))
           cat(stringr::str_interp("The p-value of the two-sided permutation t-test is ${sprintf(current_pval, fmt = '%#.4f')}, calculated for legacy purposes only."))
           cat("\n\n")
           i <- i + 1
@@ -161,7 +161,7 @@ print_each_comparism_effectsize <- function(dabest_effectsize_obj, effectsize) {
     test_groups <- dabest_effectsize_obj$idx[2:length(dabest_effectsize_obj$idx)]
 
     for (current_test_group in test_groups) {
-      cat(stringr::str_interp("The ${paired_status} ${es} between ${current_test_group} and ${control_group} is ${difference} [${ci}%CI ${bca_low}, ${bca_high}].\n"))
+      cat(stringr::str_interp("The ${paired_status} ${es} between ${current_test_group} and ${control_group} is ${difference}, ${ci}% CI [${bca_low}, ${bca_high}].\n"))
       cat(stringr::str_interp("The p-value of the two-sided permutation t-test is ${sprintf(current_pval, fmt = '%#.4f')}, calculated for legacy purposes only.\n"))
     }
   }

--- a/R/999_plot_kwargs.R
+++ b/R/999_plot_kwargs.R
@@ -44,7 +44,8 @@
 #' paired proportion plot.
 #' - `flow` Default TRUE. Boolean value determining whether the bars will be plotted in pairs.
 #' - `custom_palette` Default "d3". String. The following palettes are available for use:
-#' npg, aaas, nejm, lancet, jama, jco, ucscgb, d3, locuszoom, igv, cosmic, uchicago, brewer, ordinal, viridis_d.
+#' npg, aaas, nejm, lancet, jama, jco, ucscgb, d3, locuszoom, igv, cosmic, uchicago, brewer, ordinal, viridis_d, manual.
+#' - `palette_values` Default NULL. A vector of colors to be used, when the manual palette is selected.
 #' - `contrast_bars` Default TRUE. Whether or not to display the contrast bars at the delta plot.
 #' - `params_contrast_bars`. Default value: list(color = NULL, alpha = 0.3). Pass relevant keyword arguments to the contrast bars.
 #' - `swarm_bars` Default TRUE. Whether or not to display the swarm bars.
@@ -61,6 +62,7 @@ NULL
 assign_plot_kwargs <- function(dabest_effectsize_obj, plot_kwargs) {
   check_effectsize_object(dabest_effectsize_obj)
   custom_palette <- "d3"
+  palette_values <- NULL
 
   swarm_label <- dabest_effectsize_obj$raw_y_labels
   contrast_label <- dabest_effectsize_obj$delta_y_labels
@@ -104,6 +106,9 @@ assign_plot_kwargs <- function(dabest_effectsize_obj, plot_kwargs) {
   }
   if (!(is.null(plot_kwargs$custom_palette))) {
     custom_palette <- plot_kwargs$custom_palette
+  }
+  if (!(is.null(plot_kwargs$palette_values))) {
+    palette_values <- plot_kwargs$palette_values
   }
   if (!(is.null(plot_kwargs$swarm_ylim))) {
     swarm_ylim <- plot_kwargs$swarm_ylim
@@ -271,6 +276,7 @@ assign_plot_kwargs <- function(dabest_effectsize_obj, plot_kwargs) {
     swarm_label = swarm_label,
     contrast_label = contrast_label,
     custom_palette = custom_palette,
+    palette_values = palette_values,
     swarm_ylim = swarm_ylim,
     contrast_ylim = contrast_ylim,
     delta2_ylim = delta2_ylim,

--- a/R/999_plot_palettes.R
+++ b/R/999_plot_palettes.R
@@ -7,9 +7,16 @@
 apply_palette <- function(ggplot_object, palette_name, palette_values = NULL, num_groups, delta = FALSE) {
   
   palette_values <- get_palette_colours(palette_name, num_groups, palette_values, delta)
-
-  ggplot_object <- ggplot_object +
-    ggplot2::scale_color_manual(values = palette_values) + ggplot2::scale_fill_manual(values = palette_values)
+  
+  # a warning here is inevitable because we cannot check beforehand if the
+  # ggplot_objects uses color and/or fill aesthetics
+  if(delta) {
+    ggplot_object <- ggplot_object +
+      ggplot2::scale_fill_manual(values = palette_values)
+  } else{
+    ggplot_object <- ggplot_object +
+      ggplot2::scale_color_manual(values = palette_values) + ggplot2::scale_fill_manual(values = palette_values)
+  }
   
   return(ggplot_object)
 }
@@ -35,12 +42,12 @@ get_palette_colours <- function(palette_name, num_colours, palette_values = NULL
                     "ordinal" = viridisLite::viridis(n = num_colours, option = "viridis"),
                     "viridis_d" = viridisLite::viridis(n = num_colours, option = "viridis"),
                     "manual" = palette_values,
-                    "default" = ggplot2::hue_pal()(num_colours)
+                    "default" = scales::hue_pal()(num_colours)
   )
   if(delta) {
     names(colours) <- as.character(seq_len(num_colours))
   }
-
+  
   if(is.null(colours)) {
     colours <- rep("black", num_colours)
   }
@@ -73,7 +80,7 @@ check_palette <- function(palette_name, num_groups, palette_values = NULL) {
     warning(paste0("Palette '", palette_name, "' not recognized. Using default ggplot2 colours."))
     palette_name <- "default"
   }
-
+  
   # check num_groups does not exceed max colours
   if (palette_name %in% names(max_colours)) {
     if (num_groups > max_colours[[palette_name]]) {

--- a/R/999_plot_palettes.R
+++ b/R/999_plot_palettes.R
@@ -1,9 +1,13 @@
-# Helper functions that deal with assignment of colour palettes for the overall plots
-#
-# Contains function `apply_palette`.
-
-# Applies palettes to <ggplot> objects
-# TODO add proper documentation.
+#' Apply palette to ggplot object
+#'
+#' @param ggplot_object ggplot object to apply palette to
+#' @param palette_name name of palette to be used
+#' @param palette_values character vector of colours for manual palette
+#' @param num_groups maximum number of groups in raw or delta plot
+#' @param delta logical to indicate if colours for a delta plot are being generated
+#'
+#' @returns ggplot object with applied palette
+#' @noRd
 apply_palette <- function(ggplot_object, palette_name, palette_values = NULL, num_groups, delta = FALSE) {
   
   palette_values <- get_palette_colours(palette_name, num_groups, palette_values, delta)
@@ -21,6 +25,15 @@ apply_palette <- function(ggplot_object, palette_name, palette_values = NULL, nu
   return(ggplot_object)
 }
 
+#' Retrieve palette colours
+#'
+#' @param palette_name name of palette to be used
+#' @param num_colours number of colours to generate
+#' @param palette_values character vector of colours for manual palette
+#' @param delta logical to indicate if colours for a delta plot are being generated
+#'
+#' @returns character vector of colours
+#' @noRd
 get_palette_colours <- function(palette_name, num_colours, palette_values = NULL, delta = FALSE) {
   # check palette is valid
   palette_name <- check_palette(palette_name, num_colours, palette_values)
@@ -54,6 +67,17 @@ get_palette_colours <- function(palette_name, num_colours, palette_values = NULL
   return(colours)
 }
 
+
+
+#' Check palette validity
+#'
+#' @param palette_name name of palette to be used
+#' @param num_groups number of groups to be coloured
+#' @param palette_values character vector of colours for manual palette
+#'
+#' @returns string with valid palette name
+#' @noRd
+#'
 check_palette <- function(palette_name, num_groups, palette_values = NULL) {
   # list of max colours per palette
   max_colours <- list(

--- a/R/999_plot_palettes.R
+++ b/R/999_plot_palettes.R
@@ -4,51 +4,17 @@
 
 # Applies palettes to <ggplot> objects
 # TODO add proper documentation.
-apply_palette <- function(ggplot_object, palette_name, palette_values = NULL, num_groups) {
-  # check palette is valid
-  palette_name <- check_palette(palette_name, num_groups, palette_values)
-  ggplot_object <- switch(
-    palette_name,
-    "npg" =
-      ggplot_object + ggsci::scale_color_npg() + ggsci::scale_fill_npg(),
-    "aaas" =
-      ggplot_object + ggsci::scale_color_aaas() + ggsci::scale_fill_aaas(),
-    "nejm" =
-      ggplot_object + ggsci::scale_color_nejm() + ggsci::scale_fill_nejm(),
-    "lancet" =
-      ggplot_object + ggsci::scale_color_lancet() + ggsci::scale_fill_lancet(),
-    "jama" =
-      ggplot_object + ggsci::scale_color_jama() + ggsci::scale_fill_jama(),
-    "jco" =
-      ggplot_object + ggsci::scale_color_jco() + ggsci::scale_fill_jco(),
-    "ucscgb" =
-      ggplot_object + ggsci::scale_color_ucscgb() + ggsci::scale_fill_ucscgb(),
-    "d3" =
-      ggplot_object + ggsci::scale_color_d3() + ggsci::scale_fill_d3(),
-    "locuszoom" =
-      ggplot_object + ggsci::scale_color_locuszoom() + ggsci::scale_fill_locuszoom(),
-    "igv" =
-      ggplot_object + ggsci::scale_color_igv() + ggsci::scale_fill_igv(),
-    "cosmic" =
-      ggplot_object + ggsci::scale_color_cosmic() + ggsci::scale_fill_cosmic(),
-    "uchicago" =
-      ggplot_object + ggsci::scale_color_uchicago() + ggsci::scale_fill_uchicago(),
-    "brewer" =
-      ggplot_object + ggplot2::scale_color_brewer() + ggplot2::scale_fill_brewer(),
-    "ordinal" =
-      ggplot_object + ggplot2::scale_color_ordinal() + ggplot2::scale_fill_ordinal(),
-    "viridis_d" =
-      ggplot_object + ggplot2::scale_color_viridis_d() + ggplot2::scale_fill_viridis_d(),
-    "manual" =
-      ggplot_object + ggplot2::scale_color_manual(values = palette_values) + ggplot2::scale_fill_manual(values = palette_values),
-    "default" =
-      ggplot_object
-  )
+apply_palette <- function(ggplot_object, palette_name, palette_values = NULL, num_groups, delta = FALSE) {
+  
+  palette_values <- get_palette_colours(palette_name, num_groups, palette_values, delta)
+
+  ggplot_object <- ggplot_object +
+    ggplot2::scale_color_manual(values = palette_values) + ggplot2::scale_fill_manual(values = palette_values)
   
   return(ggplot_object)
 }
 
-get_palette_colours <- function(palette_name, num_colours, palette_values = NULL) {
+get_palette_colours <- function(palette_name, num_colours, palette_values = NULL, delta = FALSE) {
   # check palette is valid
   palette_name <- check_palette(palette_name, num_colours, palette_values)
   # palette function by name
@@ -68,8 +34,13 @@ get_palette_colours <- function(palette_name, num_colours, palette_values = NULL
                     "brewer" = RColorBrewer::brewer.pal(num_colours, "Accent"),
                     "ordinal" = viridisLite::viridis(n = num_colours, option = "viridis"),
                     "viridis_d" = viridisLite::viridis(n = num_colours, option = "viridis"),
-                    "manual" = palette_values
+                    "manual" = palette_values,
+                    "default" = ggplot2::hue_pal()(num_colours)
   )
+  if(delta) {
+    names(colours) <- as.character(seq_len(num_colours))
+  }
+
   if(is.null(colours)) {
     colours <- rep("black", num_colours)
   }
@@ -82,21 +53,27 @@ check_palette <- function(palette_name, num_groups, palette_values = NULL) {
     "d3" = 10,
     "npg" = 10,
     "aaas" = 10,
-    "nejm" = 10,
+    "nejm" = 8,
     "lancet" = 9,
     "jama" = 7,
     "jco" = 10,
     "ucscgb" = 26,
-    "d3" = 20,
-    "locuszoom" = 12,
-    "igv" = 20,
-    "cosmic" = 12,
-    "uchicago" = 10,
+    "locuszoom" = 7,
+    "igv" = 51,
+    "cosmic" = 10,
+    "uchicago" = 9,
     "brewer" = 8,
     "ordinal" = Inf,
     "viridis_d" = Inf,
-    "manual" = Inf
+    "manual" = Inf,
+    "default" = Inf
   )
+  # validate palette name
+  if (!(palette_name %in% names(max_colours))) {
+    warning(paste0("Palette '", palette_name, "' not recognized. Using default ggplot2 colours."))
+    palette_name <- "default"
+  }
+
   # check num_groups does not exceed max colours
   if (palette_name %in% names(max_colours)) {
     if (num_groups > max_colours[[palette_name]]) {

--- a/R/999_plot_palettes.R
+++ b/R/999_plot_palettes.R
@@ -4,8 +4,11 @@
 
 # Applies palettes to <ggplot> objects
 # TODO add proper documentation.
-apply_palette <- function(ggplot_object, palette_name) {
-  ggplot_object <- switch(palette_name,
+apply_palette <- function(ggplot_object, palette_name, palette_values = NULL, num_groups) {
+  # check palette is valid
+  palette_name <- check_palette(palette_name, num_groups, palette_values)
+  ggplot_object <- switch(
+    palette_name,
     "npg" =
       ggplot_object + ggsci::scale_color_npg() + ggsci::scale_fill_npg(),
     "aaas" =
@@ -35,30 +38,80 @@ apply_palette <- function(ggplot_object, palette_name) {
     "ordinal" =
       ggplot_object + ggplot2::scale_color_ordinal() + ggplot2::scale_fill_ordinal(),
     "viridis_d" =
-      ggplot_object + ggplot2::scale_color_viridis_d() + ggplot2::scale_fill_viridis_d()
+      ggplot_object + ggplot2::scale_color_viridis_d() + ggplot2::scale_fill_viridis_d(),
+    "manual" =
+      ggplot_object + ggplot2::scale_color_manual(values = palette_values) + ggplot2::scale_fill_manual(values = palette_values),
+    "default" =
+      ggplot_object
   )
-
+  
   return(ggplot_object)
 }
 
-get_palette_colours <- function(palette_name, num_colours) {
+get_palette_colours <- function(palette_name, num_colours, palette_values = NULL) {
+  # check palette is valid
+  palette_name <- check_palette(palette_name, num_colours, palette_values)
   # palette function by name
   colours <- switch(palette_name,
-    "npg" = ggsci::pal_npg()(num_colours),
-    "aaas" = ggsci::pal_aaas()(num_colours),
-    "nejm" = ggsci::pal_nejm()(num_colours),
-    "lancet" = ggsci::pal_lancet()(num_colours),
-    "jama" = ggsci::pal_jama()(num_colours),
-    "jco" = ggsci::pal_jco()(num_colours),
-    "ucscgb" = ggsci::pal_ucscgb()(num_colours),
-    "d3" = ggsci::pal_d3()(num_colours),
-    "locuszoom" = ggsci::pal_locuszoom()(num_colours),
-    "igv" = ggsci::pal_igv()(num_colours),
-    "cosmic" = ggsci::pal_cosmic()(num_colours),
-    "uchicago" = ggsci::pal_uchicago()(num_colours),
-    "brewer" = RColorBrewer::brewer.pal()(num_colours),
-    "ordinal" = viridisLite::viridis(n = num_colours, option = "viridis"),
-    "viridis_d" = viridisLite::viridis(n = num_colours, option = "viridis")
+                    "npg" = ggsci::pal_npg()(num_colours),
+                    "aaas" = ggsci::pal_aaas()(num_colours),
+                    "nejm" = ggsci::pal_nejm()(num_colours),
+                    "lancet" = ggsci::pal_lancet()(num_colours),
+                    "jama" = ggsci::pal_jama()(num_colours),
+                    "jco" = ggsci::pal_jco()(num_colours),
+                    "ucscgb" = ggsci::pal_ucscgb()(num_colours),
+                    "d3" = ggsci::pal_d3()(num_colours),
+                    "locuszoom" = ggsci::pal_locuszoom()(num_colours),
+                    "igv" = ggsci::pal_igv()(num_colours),
+                    "cosmic" = ggsci::pal_cosmic()(num_colours),
+                    "uchicago" = ggsci::pal_uchicago()(num_colours),
+                    "brewer" = RColorBrewer::brewer.pal(num_colours, "Accent"),
+                    "ordinal" = viridisLite::viridis(n = num_colours, option = "viridis"),
+                    "viridis_d" = viridisLite::viridis(n = num_colours, option = "viridis"),
+                    "manual" = palette_values
   )
+  if(is.null(colours)) {
+    colours <- rep("black", num_colours)
+  }
   return(colours)
+}
+
+check_palette <- function(palette_name, num_groups, palette_values = NULL) {
+  # list of max colours per palette
+  max_colours <- list(
+    "d3" = 10,
+    "npg" = 10,
+    "aaas" = 10,
+    "nejm" = 10,
+    "lancet" = 9,
+    "jama" = 7,
+    "jco" = 10,
+    "ucscgb" = 26,
+    "d3" = 20,
+    "locuszoom" = 12,
+    "igv" = 20,
+    "cosmic" = 12,
+    "uchicago" = 10,
+    "brewer" = 8,
+    "ordinal" = Inf,
+    "viridis_d" = Inf,
+    "manual" = Inf
+  )
+  # check num_groups does not exceed max colours
+  if (palette_name %in% names(max_colours)) {
+    if (num_groups > max_colours[[palette_name]]) {
+      warning(paste0("The selected palette '", palette_name, "' may not have enough
+ colours for ", num_groups, " groups. Switching to 'default' ggplot2 colours."))  
+      palette_name <- "default"
+    }
+  }
+  # check manual palette has enough colours
+  if (palette_name == "manual") {
+    if (is.null(palette_values) | length(palette_values) < num_groups) {
+      warning("Manual palette selected but insufficient colours provided. Using default ggplot2 colours.")
+      palette_name <- "default"
+    }
+  }
+  
+  return(palette_name)
 }

--- a/man/plot_kwargs.Rd
+++ b/man/plot_kwargs.Rd
@@ -41,7 +41,8 @@ the zero line of the effect size for the control-control group.
 paired proportion plot.
 \item \code{flow} Default TRUE. Boolean value determining whether the bars will be plotted in pairs.
 \item \code{custom_palette} Default "d3". String. The following palettes are available for use:
-npg, aaas, nejm, lancet, jama, jco, ucscgb, d3, locuszoom, igv, cosmic, uchicago, brewer, ordinal, viridis_d.
+npg, aaas, nejm, lancet, jama, jco, ucscgb, d3, locuszoom, igv, cosmic, uchicago, brewer, ordinal, viridis_d, manual.
+\item \code{palette_values} Default NULL. A vector of colors to be used, when the manual palette is selected.
 \item \code{contrast_bars} Default TRUE. Whether or not to display the contrast bars at the delta plot.
 \item \code{params_contrast_bars}. Default value: list(color = NULL, alpha = 0.3). Pass relevant keyword arguments to the contrast bars.
 \item \code{swarm_bars} Default TRUE. Whether or not to display the swarm bars.


### PR DESCRIPTION
This PR is an enhancement to `{dabestr}` and fixes a couple of issues with colouring `dabest_plots`.

- Enhancement: Users should be able to supply a custom palette for use in graphics (issue #160)
- Fix: if a `dabest_plot` with more than 9 groups is requested, resulting plot is missing bars (issue #175)
- Fix: if a `dabest_plot` with more than 9 groups is requested, colour scheme is broken (issue #175)
- Fix: If a `dabest_plot` with more than n groups is requested, plot creation fails (where n is the maximum colours in custom palette, issue #175).

I also merged the changes from marsiwiec which fixes the formatting of the print statements and adds an option to silence the greeting.

## Issues (MWE)

Using the current version of `{dabestr}` the following code illustrates the issues:

```r
library(dabestr)
set.seed(12345)
N <- 20

df <- tibble::tibble(
  ca = rnorm(N, mean = 3, sd = 0.4),
  cb = rnorm(N, mean = 3.5, sd = 0.75),
  cc = rnorm(N, mean = 3.25, sd = 0.4),
  cd = rnorm(N, mean = 3, sd = 0.4),
  ce = rnorm(N, mean = 3.5, sd = 0.75),
  cf = rnorm(N, mean = 3.25, sd = 0.4),
  cg = rnorm(N, mean = 3, sd = 0.4),
  ch = rnorm(N, mean = 3.5, sd = 0.75),
  ci = rnorm(N, mean = 3.25, sd = 0.4),
  cj = rnorm(N, mean = 3.5, sd = 0.75),
  ta = rnorm(N, mean = 3.5, sd = 0.5)
)

df <- df |>
  tidyr::gather(key = Group, value = Measurement)

sub9.mean_diff <- load(df, x = Group, y = Measurement,
                       idx = c(
                         "ca", "cb", "cc", "cd", "ce",
                         "cf", "cg", "ch", "ci"
                       )) |> mean_diff()

sub10.mean_diff <- load(df, x = Group, y = Measurement,
                        idx = c(
                          "ca", "cb", "cc", "cd", "ce",
                          "cf", "cg", "ch", "ci", "cj"
                        )) |> mean_diff()

sub11.mean_diff <- load(df, x = Group, y = Measurement,
                        idx = c(
                          "ca", "cb", "cc", "cd", "ce",
                          "cf", "cg", "ch", "ci", "cj", "ta"
                        )) |> mean_diff()

# jama has only 7 colours - requested plot fails with empty groups for 8 & 9
dabest_plot(sub9.mean_diff, custom_palette = "jama")

# output is ok using uscgb, which has enough colours. 9 groups works as intended
dabest_plot(sub9.mean_diff, custom_palette = "ucscgb")

# output is in incorrect with 10 groups
# - colours do not match between raw and delta plots
dabest_plot(sub10.mean_diff, custom_palette = "ucscgb")

# output is in incorrect with 11 groups
# - colours do not match between raw and delta plots
# - colour mismatch between swarm plot and swarm bars in raw plot
dabest_plot(sub11.mean_diff, custom_palette = "ucscgb")
```
With the proposed changes, the last four commands all work correctly.

The enhancement I am proposing is to add manual colouring to the graphics.

```r
# ENHANCEMENT: Define a custom palette with enough colors
my_palette <- c("#e6194b", "#3cb44b", "#ffe119", "#4363d8", "#f58231",
                "#911eb4", "#46f0f0", "#f032e6", "#bcf60c", "#fabebe",
                "#008080", "#e6beff", "#9a6324", "#fffac8", "#800000",
                "#aaffc3", "#808000", "#ffd8b1", "#000075", "#808080",
                "#ffffff", "#000000")

dabest_plot(sub11.mean_diff,
            custom_palette = "manual",
            palette_values = my_palette)
```
Briefly, the issue with groups exceeding the maximum in the palette is solved by a check which uses default ggplot2 colours if the palette is exceeded.

The issue of more than 9 groups causing errors was fixed by factoring the x positions so that they are in numeric order (i.e. 10 follows 9 rather than 1). However this also required naming the palette so that it can be applied correctly to Cumming plots (as these have missing categories). This choice meant that `apply_palette()` had to be rewritten. The only alternative would've been to manually colour each bar and violin as is done for the text markers and this felt too hacky to be a solution.